### PR TITLE
fix error undefined variable $name on embed()

### DIFF
--- a/src/PDF.php
+++ b/src/PDF.php
@@ -262,7 +262,7 @@ class PDF extends Mpdf
      */
     public function embed(string $filename = '')
     {
-        return $this->Output($name ?: $this->filename, Destination::STRING_RETURN);
+        return $this->Output($filename ?: $this->filename, Destination::STRING_RETURN);
     }
 
     /**


### PR DESCRIPTION
change $name into $filename on return value of the embed function

![image](https://github.com/user-attachments/assets/48ac6c1b-a855-4d3d-87a0-926e20fe6018)
